### PR TITLE
Remove deprecated 'version' key from docker-compose files

### DIFF
--- a/docker-compose-contracting.yml
+++ b/docker-compose-contracting.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   contracting:
     hostname: contracting-dev-shell

--- a/docker-compose-core-bds.yml
+++ b/docker-compose-core-bds.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 networks:
   xian-net:
     internal: false  # Allow internet access for package installation

--- a/docker-compose-core-dev.yml
+++ b/docker-compose-core-dev.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 networks:
   xian-net:
     internal: false  # Allow internet access for package installation

--- a/docker-compose-core.yml
+++ b/docker-compose-core.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 networks:
   xian-net:
     internal: false  # Allow internet access for package installation


### PR DESCRIPTION
## Summary

Docker Compose V2 no longer requires the `version` key and actively warns about it:

```
level=warning msg="the attribute 'version' is obsolete, it will be ignored, please remove it to avoid potential confusion"
```

This PR removes the deprecated key from all docker-compose files.

## Changes

- `docker-compose-core.yml`
- `docker-compose-core-bds.yml`
- `docker-compose-core-dev.yml`
- `docker-compose-contracting.yml`

## Testing

Tested locally - all compose commands work correctly without the version key.